### PR TITLE
Update azure authentication

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run tests",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "dotnet",
+      "args": [
+        "test"
+      ],
+      "cwd": "${workspaceFolder}/tests/AzureFunctions.Tests",
+      "console": "internalConsole",
+      "stopAtEntry": false,
+      "internalConsoleOptions": "openOnSessionStart"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/tests/AzureFunctions.Tests/AzureFunctions.Tests.csproj"
+      ],
+      "problemMatcher": "$msCompile"
+    }
+  ]
+}

--- a/AzureFunctions.sln
+++ b/AzureFunctions.sln
@@ -39,6 +39,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{8234
 		.github\PULL_REQUEST_TEMPLATE.md = .github\PULL_REQUEST_TEMPLATE.md
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".vscode", ".vscode", "{2C2BECF8-7566-4915-A71A-96D4CDC59D1A}"
+	ProjectSection(SolutionItems) = preProject
+		.vscode\launch.json = .vscode\launch.json
+		.vscode\tasks.json = .vscode\tasks.json
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -61,6 +67,7 @@ Global
 		{7FFC997F-CFD1-459D-BB2B-A8F5EF938FA9} = {1C34EAC2-8F8F-403F-A7E3-5A7DEC1E9C09}
 		{7888A115-3473-4BBE-8955-E263AADC611C} = {37C847B2-8840-4771-B0A8-2EE98DDB9022}
 		{8234696E-DF1D-4359-9C2D-5445D01588C7} = {ECFE585A-7DC5-463D-A1B5-340383CC6228}
+		{2C2BECF8-7566-4915-A71A-96D4CDC59D1A} = {ECFE585A-7DC5-463D-A1B5-340383CC6228}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {EEDFC93E-B949-493C-A5F1-F22175F982C1}

--- a/README.md
+++ b/README.md
@@ -8,3 +8,30 @@
 ## Overview
 
 A repository containing my custom Azure Functions.
+
+## Functions
+
+### DNSimpleWebhook
+
+#### Configuration
+
+| **Key** | **Default Value** | **Description**
+|:--|:-:|:-:|
+| `CERTIFICATE_PASSWORD` | _None_ | _TODO_ |
+| `CERTIFICATE_STORE_CONNECTION` | _None_ | _TODO_ |
+| `DNSIMPLE_URL` | `https://api.dnsimple.com` | _TODO_ |
+| `DNSIMPLE_TOKEN` | _None_ | _TODO_ |
+
+### BindPrivateCertificate
+
+#### Configuration
+
+| **Key** | **Default Value** | **Description**
+|:--|:-:|:-:|
+| `AZURE_CREDENTIALS_FILE` | `%USERPROFILE%\.azure\credentials.json` | _TODO_ |
+| `AZURE_SUBSCRIPTION_ID` | _None_ | _TODO_ |
+| `CERTIFICATE_PASSWORD` | _None_ | _TODO_ |
+| `CERTIFICATE_STORE_CONNECTION` | _None_ | _TODO_ |
+| `USE_MANAGED_SERVICE_IDENTITY` | `false` | _TODO_ |
+
+You must also set `WEBSITE_LOAD_CERTIFICATES` to `*` in the function's Application settings in the Azure portal so that the private keys for X.509 certificates can be loaded.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ A repository containing my custom Azure Functions.
 | `AZURE_SUBSCRIPTION_ID` | _None_ | _TODO_ |
 | `CERTIFICATE_PASSWORD` | _None_ | _TODO_ |
 | `CERTIFICATE_STORE_CONNECTION` | _None_ | _TODO_ |
+| `SERVICE_PRINCIPAL_CLIENT_ID` | _None_ | _TODO_ |
+| `SERVICE_PRINCIPAL_CLIENT_SECRET` | _None_ | _TODO_ |
+| `SERVICE_PRINCIPAL_TENANT_ID` | _None_ | _TODO_ |
 | `USE_MANAGED_SERVICE_IDENTITY` | `false` | _TODO_ |
+| `USE_SERVICE_PRINCIPAL` | `true` | _TODO_ |
 
 You must also set `WEBSITE_LOAD_CERTIFICATES` to `*` in the function's Application settings in the Azure portal so that the private keys for X.509 certificates can be loaded.

--- a/README.md
+++ b/README.md
@@ -13,29 +13,56 @@ A repository containing my custom Azure Functions.
 
 ### DNSimpleWebhook
 
+A function that acts as a receiver for webhooks from the [DNSimple API](https://dnsimple.com/webhooks). Only `v2` of the API and the `certificate.reissue` payload are currently supported.
+
+The function queries the DNSimple API for the associated certificate re-issue (such as for a [LetsEncrypt](https://letsencrypt.org/) TLS certificate) to obtain the certificate chain, public, and private keys, which are then uploaded as blobs to an Azure storage account container. A PFX file is also generated using the public and private key and uploaded to the same blob container.
+
+Files are stored in the `certificates` container in the configured storage account using the naming convention shown below where the files are available from the DNSimple API.
+
+  * `{commonName}_{thumbprint}_{timestamp}.cert.pem`
+  * `{commonName}_{thumbprint}_{timestamp}.chain.pem`
+  * `{commonName}_{thumbprint}_{timestamp}.chain.{index}.pem`
+  * `{commonName}_{thumbprint}_{timestamp}.root.pem`
+  * `{commonName}_{thumbprint}_{timestamp}.privkey.pem`
+  * `{commonName}_{thumbprint}_{timestamp}.privkey.pfx`
+
+
+  1. `{commonName}` is the Common Name (`CN={commonName}`) value from the certificate with `.` characters replaced by `_`.
+  1. `{thumbprint}` is the lower-case thumbprint of the certificate.
+  1. `{timestamp}` is the _Not Before_ UTC date of the certificate in the format `yyy-MM-dd`.
+
 #### Configuration
 
 | **Key** | **Default Value** | **Description**
 |:--|:-:|:-:|
-| `CERTIFICATE_PASSWORD` | _None_ | _TODO_ |
-| `CERTIFICATE_STORE_CONNECTION` | _None_ | _TODO_ |
-| `DNSIMPLE_URL` | `https://api.dnsimple.com` | _TODO_ |
-| `DNSIMPLE_TOKEN` | _None_ | _TODO_ |
+| `CERTIFICATE_PASSWORD` | _None_ | The password to use for generated `.pfx` files uploaded to blob storage. |
+| `CERTIFICATE_STORE_CONNECTION` | _None_ | The connection string for the blob storage account to upload certificate files to. |
+| `DNSIMPLE_URL` | `https://api.dnsimple.com` | The URL of the DNSimple API. |
+| `DNSIMPLE_TOKEN` | _None_ | The access token to use for the DNSimple API. |
 
 ### BindPrivateCertificate
 
+A function that is invoked when blobs are created/updated in the `certificates` container of the configured Azure storage account that match the naming convention `{name}.privkey.pfx` and binds them to any App Service instances in the configured Azure subscription.
+
+The certificate is bound to the TLS/SSL bindings associated with the Common Name and any Subject Alternate Names associated with the certificate for an App Service instance provided that:
+
+  1. The _Not Before_ timestamp of the certificate is in the past.
+  1. The _Not After_ timestamp of the certificate is in the future.
+  1. The host name has an existing TLS binding.
+  1. The _Thumbprint_ of the certificate differs from the currently configured certificate for the binding.
+
 #### Configuration
 
 | **Key** | **Default Value** | **Description**
 |:--|:-:|:-:|
-| `AZURE_CREDENTIALS_FILE` | `%USERPROFILE%\.azure\credentials.json` | _TODO_ |
-| `AZURE_SUBSCRIPTION_ID` | _None_ | _TODO_ |
-| `CERTIFICATE_PASSWORD` | _None_ | _TODO_ |
-| `CERTIFICATE_STORE_CONNECTION` | _None_ | _TODO_ |
-| `SERVICE_PRINCIPAL_CLIENT_ID` | _None_ | _TODO_ |
-| `SERVICE_PRINCIPAL_CLIENT_SECRET` | _None_ | _TODO_ |
-| `SERVICE_PRINCIPAL_TENANT_ID` | _None_ | _TODO_ |
-| `USE_MANAGED_SERVICE_IDENTITY` | `false` | _TODO_ |
-| `USE_SERVICE_PRINCIPAL` | `true` | _TODO_ |
+| `AZURE_CREDENTIALS_FILE` | `%USERPROFILE%\.azure\credentials.json` | The path to the Azure credentials file to use to authenticate with Azure Resource Management APIs if not using Service Principal or Managed Service Identity authentication. |
+| `AZURE_SUBSCRIPTION_ID` | _None_ | The Id of the Azure subscription to configure App Services instances in. |
+| `CERTIFICATE_PASSWORD` | _None_ | The password associated with the X.509 certificates stored in the Azure storage account. |
+| `CERTIFICATE_STORE_CONNECTION` | _None_ | The connection string for the blob storage account which X.509 certificates are stored in. |
+| `SERVICE_PRINCIPAL_CLIENT_ID` | _None_ | The client Id to use for Service Principal authentication. |
+| `SERVICE_PRINCIPAL_CLIENT_SECRET` | _None_ | The client secret to use for Service Principal authentication. |
+| `SERVICE_PRINCIPAL_TENANT_ID` | _None_ | The tenant Id to use for Service Principal authentication. |
+| `USE_MANAGED_SERVICE_IDENTITY` | `false` | Whether to use Managed Service Identity authentication with Azure Resource Management APIs. |
+| `USE_SERVICE_PRINCIPAL` | `true` | Whether to use a Service Principal for authentication with Azure Resource Management APIs. |
 
 You must also set `WEBSITE_LOAD_CERTIFICATES` to `*` in the function's Application settings in the Azure portal so that the private keys for X.509 certificates can be loaded.

--- a/src/AzureFunctions/AppService/Client/AppServiceClient.cs
+++ b/src/AzureFunctions/AppService/Client/AppServiceClient.cs
@@ -69,34 +69,26 @@ namespace MartinCostello.AzureFunctions.AppService.Client
         }
 
         /// <summary>
-        /// Creates an authenticated instance of <see cref="IAzure"/>.
-        /// </summary>
-        /// <returns>
-        /// The instance of <see cref="IAzure"/> to use.
-        /// </returns>
-        protected virtual IAzure CreateService()
-        {
-            AzureCredentials credentials = CreateCredentials();
-
-            return Azure
-                .Configure()
-                .Authenticate(credentials)
-                .WithSubscription(_config.AzureSubscriptionId);
-        }
-
-        /// <summary>
         /// Creates a set of credentials to use for Azure service management.
         /// </summary>
         /// <returns>
         /// The instance of <see cref="AzureCredentials"/> to use.
         /// </returns>
-        protected virtual AzureCredentials CreateCredentials()
+        public AzureCredentials CreateCredentials()
         {
             var environment = AzureEnvironment.AzureGlobalCloud;
 
             if (_config.UseManagedServiceIdentity)
             {
                 return _credentialsFactory.FromMSI(new MSILoginInformation(MSIResourceType.AppService), environment);
+            }
+            else if (_config.UseServicePrincipalAuthentication)
+            {
+                return _credentialsFactory.FromServicePrincipal(
+                    _config.ServicePrincipalClientId,
+                    _config.ServicePrincipalClientSecret,
+                    _config.ServicePrincipalTenantId,
+                    environment);
             }
             else
             {
@@ -112,6 +104,22 @@ namespace MartinCostello.AzureFunctions.AppService.Client
 
                 return _credentialsFactory.FromFile(authFile);
             }
+        }
+
+        /// <summary>
+        /// Creates an authenticated instance of <see cref="IAzure"/>.
+        /// </summary>
+        /// <returns>
+        /// The instance of <see cref="IAzure"/> to use.
+        /// </returns>
+        protected virtual IAzure CreateService()
+        {
+            AzureCredentials credentials = CreateCredentials();
+
+            return Azure
+                .Configure()
+                .Authenticate(credentials)
+                .WithSubscription(_config.AzureSubscriptionId);
         }
     }
 }

--- a/src/AzureFunctions/DNSimple/DNSimpleService.cs
+++ b/src/AzureFunctions/DNSimple/DNSimpleService.cs
@@ -256,7 +256,7 @@ namespace MartinCostello.AzureFunctions.DNSimple
             string safeCommonName = commonName.Replace(".", "-");
 
             string thumbprintLower = certificate.Thumbprint.ToLowerInvariant();
-            string timestamp = certificate.NotBefore.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+            string timestamp = certificate.NotBefore.ToUniversalTime().ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 
             metadata["CommonName"] = commonName;
 

--- a/src/AzureFunctions/FunctionsConfiguration.cs
+++ b/src/AzureFunctions/FunctionsConfiguration.cs
@@ -14,7 +14,7 @@ namespace MartinCostello.AzureFunctions
         public string AzureCredentialsFile => GetOption("AZURE_CREDENTIALS_FILE");
 
         /// <inheritdoc />
-        public string AzureSubscriptionId => GetOption("APPSERVICE_SUBSCRIPTION_ID");
+        public string AzureSubscriptionId => GetOption("AZURE_SUBSCRIPTION_ID");
 
         /// <inheritdoc />
         public string CertificatePassword => GetOption("CERTIFICATE_PASSWORD");
@@ -28,7 +28,7 @@ namespace MartinCostello.AzureFunctions
         /// <inheritdoc />
         public string DNSimpleUrl => GetOption("DNSIMPLE_URL", "https://api.dnsimple.com");
 
-        public bool UseManagedServiceIdentity => string.Equals(GetOption("USE_MANAGED_SERVICE_IDENTITY", bool.TrueString), bool.TrueString, StringComparison.OrdinalIgnoreCase);
+        public bool UseManagedServiceIdentity => string.Equals(GetOption("USE_MANAGED_SERVICE_IDENTITY", bool.FalseString), bool.TrueString, StringComparison.OrdinalIgnoreCase);
 
         private static string GetOption(string name, string defaultValue = "") =>
             Environment.GetEnvironmentVariable(name, EnvironmentVariableTarget.Process) ?? defaultValue;

--- a/src/AzureFunctions/FunctionsConfiguration.cs
+++ b/src/AzureFunctions/FunctionsConfiguration.cs
@@ -28,7 +28,20 @@ namespace MartinCostello.AzureFunctions
         /// <inheritdoc />
         public string DNSimpleUrl => GetOption("DNSIMPLE_URL", "https://api.dnsimple.com");
 
+        /// <inheritdoc />
+        public string ServicePrincipalClientId => GetOption("SERVICE_PRINCIPAL_CLIENT_ID");
+
+        /// <inheritdoc />
+        public string ServicePrincipalClientSecret => GetOption("SERVICE_PRINCIPAL_CLIENT_SECRET");
+
+        /// <inheritdoc />
+        public string ServicePrincipalTenantId => GetOption("SERVICE_PRINCIPAL_TENANT_ID");
+
+        /// <inheritdoc />
         public bool UseManagedServiceIdentity => string.Equals(GetOption("USE_MANAGED_SERVICE_IDENTITY", bool.FalseString), bool.TrueString, StringComparison.OrdinalIgnoreCase);
+
+        /// <inheritdoc />
+        public bool UseServicePrincipalAuthentication => string.Equals(GetOption("USE_SERVICE_PRINCIPAL", bool.TrueString), bool.TrueString, StringComparison.OrdinalIgnoreCase);
 
         private static string GetOption(string name, string defaultValue = "") =>
             Environment.GetEnvironmentVariable(name, EnvironmentVariableTarget.Process) ?? defaultValue;

--- a/src/AzureFunctions/IFunctionsConfiguration.cs
+++ b/src/AzureFunctions/IFunctionsConfiguration.cs
@@ -39,8 +39,28 @@ namespace MartinCostello.AzureFunctions
         string DNSimpleUrl { get; }
 
         /// <summary>
+        /// Gets the client Id to use when <see cref="UseServicePrincipalAuthentication"/> is <see langword="true"/>.
+        /// </summary>
+        string ServicePrincipalClientId { get; }
+
+        /// <summary>
+        /// Gets the client secret to use when <see cref="UseServicePrincipalAuthentication"/> is <see langword="true"/>.
+        /// </summary>
+        string ServicePrincipalClientSecret { get; }
+
+        /// <summary>
+        /// Gets the tenant Id to use when <see cref="UseServicePrincipalAuthentication"/> is <see langword="true"/>.
+        /// </summary>
+        string ServicePrincipalTenantId { get; }
+
+        /// <summary>
         /// Gets a value indicating whether to use a Managed Service Identity for accessing Azure resources.
         /// </summary>
         bool UseManagedServiceIdentity { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether to use a Service Principal for accessing Azure resources.
+        /// </summary>
+        bool UseServicePrincipalAuthentication { get; }
     }
 }

--- a/src/AzureFunctions/local.settings.json
+++ b/src/AzureFunctions/local.settings.json
@@ -9,8 +9,8 @@
   "Values": {
     "AzureWebJobsDashboard": "UseDevelopmentStorage=true",
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-    "APPSERVICE_SUBSCRIPTION_ID": "",
     "AZURE_CREDENTIALS_FILE": "",
+    "AZURE_SUBSCRIPTION_ID": "",
     "CERTIFICATE_PASSWORD": "password",
     "CERTIFICATE_STORE_CONNECTION": "UseDevelopmentStorage=true",
     "DNSIMPLE_URL": "https://api.sandbox.dnsimple.com",

--- a/src/AzureFunctions/local.settings.json
+++ b/src/AzureFunctions/local.settings.json
@@ -15,6 +15,9 @@
     "CERTIFICATE_STORE_CONNECTION": "UseDevelopmentStorage=true",
     "DNSIMPLE_URL": "https://api.sandbox.dnsimple.com",
     "DNSIMPLE_TOKEN": "",
+    "SERVICE_PRINCIPAL_CLIENT_ID": "",
+    "SERVICE_PRINCIPAL_CLIENT_SECRET": "",
+    "SERVICE_PRINCIPAL_TENANT_ID": "",
     "USE_MANAGED_SERVICE_IDENTITY": false,
     "USE_SERVICE_PRINCIPAL": false
   }

--- a/src/AzureFunctions/local.settings.json
+++ b/src/AzureFunctions/local.settings.json
@@ -15,6 +15,7 @@
     "CERTIFICATE_STORE_CONNECTION": "UseDevelopmentStorage=true",
     "DNSIMPLE_URL": "https://api.sandbox.dnsimple.com",
     "DNSIMPLE_TOKEN": "",
-    "USE_MANAGED_SERVICE_IDENTITY": false
+    "USE_MANAGED_SERVICE_IDENTITY": false,
+    "USE_SERVICE_PRINCIPAL": false
   }
 }

--- a/tests/AzureFunctions.Tests/AppService/Client/AppServiceClientTests.cs
+++ b/tests/AzureFunctions.Tests/AppService/Client/AppServiceClientTests.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Microsoft.Azure.Management.ResourceManager.Fluent;
+using Microsoft.Azure.Management.ResourceManager.Fluent.Authentication;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace MartinCostello.AzureFunctions.AppService.Client
+{
+    public static class AppServiceClientTests
+    {
+        [Fact]
+        public static void AppServiceClient_Creates_MSI_Credentials()
+        {
+            // Arrange
+            var mock = new Mock<IFunctionsConfiguration>();
+
+            mock.Setup((p) => p.UseManagedServiceIdentity)
+                .Returns(true);
+
+            IFunctionsConfiguration config = mock.Object;
+
+            var target = new AppServiceClient(config, SdkContext.AzureCredentialsFactory);
+
+            // Act
+            AzureCredentials actual = target.CreateCredentials();
+
+            // Assert
+            actual.ShouldNotBeNull();
+            actual.Environment.ShouldBe(AzureEnvironment.AzureGlobalCloud);
+            actual.ClientId.ShouldBeNull();
+            actual.TenantId.ShouldBeNull();
+        }
+
+        [Fact]
+        public static void AppServiceClient_Creates_Service_Principal_Credentials()
+        {
+            // Arrange
+            var mock = new Mock<IFunctionsConfiguration>();
+
+            mock.Setup((p) => p.ServicePrincipalClientId).Returns("client_id");
+            mock.Setup((p) => p.ServicePrincipalClientSecret).Returns("client_secret");
+            mock.Setup((p) => p.ServicePrincipalTenantId).Returns("tenant_id");
+            mock.Setup((p) => p.UseServicePrincipalAuthentication).Returns(true);
+
+            IFunctionsConfiguration config = mock.Object;
+
+            var target = new AppServiceClient(config, SdkContext.AzureCredentialsFactory);
+
+            // Act
+            AzureCredentials actual = target.CreateCredentials();
+
+            // Assert
+            actual.ShouldNotBeNull();
+            actual.Environment.ShouldBe(AzureEnvironment.AzureGlobalCloud);
+            actual.ClientId.ShouldBe("client_id");
+            actual.TenantId.ShouldBe("tenant_id");
+        }
+    }
+}

--- a/tests/AzureFunctions.Tests/FunctionsConfigurationTests.cs
+++ b/tests/AzureFunctions.Tests/FunctionsConfigurationTests.cs
@@ -17,7 +17,7 @@ namespace MartinCostello.AzureFunctions
             var environment = new Dictionary<string, string>()
             {
                 { "AZURE_CREDENTIALS_FILE", "azure-creds.json" },
-                { "APPSERVICE_SUBSCRIPTION_ID", "my_subscription_id" },
+                { "AZURE_SUBSCRIPTION_ID", "my_subscription_id" },
                 { "CERTIFICATE_PASSWORD", "my_password" },
                 { "CERTIFICATE_STORE_CONNECTION", "UseDevelopmentStorage=true" },
                 { "DNSIMPLE_TOKEN", "my_token" },

--- a/tests/AzureFunctions.Tests/FunctionsConfigurationTests.cs
+++ b/tests/AzureFunctions.Tests/FunctionsConfigurationTests.cs
@@ -22,7 +22,11 @@ namespace MartinCostello.AzureFunctions
                 { "CERTIFICATE_STORE_CONNECTION", "UseDevelopmentStorage=true" },
                 { "DNSIMPLE_TOKEN", "my_token" },
                 { "DNSIMPLE_URL", "https://dnsimple.local" },
+                { "SERVICE_PRINCIPAL_CLIENT_ID", "client_id" },
+                { "SERVICE_PRINCIPAL_CLIENT_SECRET", "client_secret" },
+                { "SERVICE_PRINCIPAL_TENANT_ID", "tenant_id" },
                 { "USE_MANAGED_SERVICE_IDENTITY", "false" },
+                { "USE_SERVICE_PRINCIPAL", "true" },
             };
 
             foreach (var pair in environment)
@@ -42,7 +46,11 @@ namespace MartinCostello.AzureFunctions
                 target.CertificateStoreConnectionString.ShouldBe("UseDevelopmentStorage=true");
                 target.DNSimpleToken.ShouldBe("my_token");
                 target.DNSimpleUrl.ShouldBe("https://dnsimple.local");
+                target.ServicePrincipalClientId.ShouldBe("client_id");
+                target.ServicePrincipalClientSecret.ShouldBe("client_secret");
+                target.ServicePrincipalTenantId.ShouldBe("tenant_id");
                 target.UseManagedServiceIdentity.ShouldBe(false);
+                target.UseServicePrincipalAuthentication.ShouldBe(true);
             }
             finally
             {


### PR DESCRIPTION
It turns out that Managed Service Identity is not yet supported to authenticate an Azure Function calling the Azure Resource Management APIs.

To make the function work in the meantime, this PR adds support for using a Service Principal for authentication (as well as the existing MSI and file mechanisms), with Service Principal now being the default.

Also:
  * Renames the `APPSERVICE_SUBSCRIPTION_ID` setting to `AZURE_SUBSCRIPTION_ID`.
  * Adds assets for running tests using VS Code.
  * Adds documentation for the functions to `README`.
  * Fix local date being used for certificate filenames, instead of UTC.
  * Adds unit tests for some of the authentication mechanisms.