### PR TITLE
Fix incorrect payload name

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A repository containing my custom Azure Functions.
 
 ### DNSimpleWebhook
 
-A function that acts as a receiver for webhooks from the [DNSimple API](https://dnsimple.com/webhooks). Only `v2` of the API and the `certificate.reissue` payload are currently supported.
+A function that acts as a receiver for webhooks from the [DNSimple API](https://dnsimple.com/webhooks). Only `v2` of the API and the `certificate.issue` payload are currently supported.
 
 The function queries the DNSimple API for the associated certificate re-issue (such as for a [LetsEncrypt](https://letsencrypt.org/) TLS certificate) to obtain the certificate chain, public, and private keys, which are then uploaded as blobs to an Azure storage account container. A PFX file is also generated using the public and private key and uploaded to the same blob container.
 

--- a/src/AzureFunctions/DNSimple/DNSimpleService.cs
+++ b/src/AzureFunctions/DNSimple/DNSimpleService.cs
@@ -133,7 +133,7 @@ namespace MartinCostello.AzureFunctions.DNSimple
                 return false;
             }
 
-            if (!string.Equals(payload.Name, "certificate.reissue", StringComparison.Ordinal))
+            if (!string.Equals(payload.Name, "certificate.issue", StringComparison.Ordinal))
             {
                 _logger.LogInformation("DNSimple payload {Id} is of an unknown name: {Name}", payload.RequestId, payload.Name);
                 return false;

--- a/tests/AzureFunctions.Tests/AzureFunctions.Tests.csproj
+++ b/tests/AzureFunctions.Tests/AzureFunctions.Tests.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="JustEat.HttpClientInterception" Version="1.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="NodaTime.Testing" Version="2.2.5" />
     <PackageReference Include="Shouldly" Version="3.0.0" />

--- a/tests/AzureFunctions.Tests/WebhookPayloadHelpers.cs
+++ b/tests/AzureFunctions.Tests/WebhookPayloadHelpers.cs
@@ -21,7 +21,7 @@ namespace MartinCostello.AzureFunctions
         {
             return new WebhookPayload()
             {
-                Name = "certificate.reissue",
+                Name = "certificate.issue",
                 ApiVersion = "v2",
                 RequestId = "abc123",
                 Account = new WebhookAccount()


### PR DESCRIPTION
Fix incorrect expected payload name that mean that webhooks for certificates weren't processed.

Also updates the .NET Core test SDK to the latest version.