### PR TITLE
Fix binding errors

### DIFF
--- a/src/AzureFunctions/AppService/CertificateService.cs
+++ b/src/AzureFunctions/AppService/CertificateService.cs
@@ -203,6 +203,7 @@ namespace MartinCostello.AzureFunctions.AppService
                 await _client.UpdateBindingAsync(
                     application,
                     hostName,
+                    certificate.Thumbprint,
                     certificate.RawData,
                     certificate.Password);
 

--- a/src/AzureFunctions/AppService/Client/IAppServiceClient.cs
+++ b/src/AzureFunctions/AppService/Client/IAppServiceClient.cs
@@ -25,6 +25,7 @@ namespace MartinCostello.AzureFunctions.AppService.Client
         /// </summary>
         /// <param name="application">The application to update the TLS binding for.</param>
         /// <param name="hostName">The host name to bind the certificate to.</param>
+        /// <param name="thumbprint">The thumbprint of the certificate.</param>
         /// <param name="certificate">The raw bytes of the certificate to bind.</param>
         /// <param name="password">The certificate password.</param>
         /// <returns>
@@ -34,6 +35,7 @@ namespace MartinCostello.AzureFunctions.AppService.Client
         Task<IWebApp> UpdateBindingAsync(
             IWebApp application,
             string hostName,
+            string thumbprint,
             byte[] certificate,
             string password);
     }

--- a/src/AzureFunctions/AzureFunctions.csproj
+++ b/src/AzureFunctions/AzureFunctions.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.13" />
-    <PackageReference Include="Microsoft.Azure.Management.AppService.Fluent" Version="1.9.1" />
-    <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.9.1" />
+    <PackageReference Include="Microsoft.Azure.Management.AppService.Fluent" Version="1.11.1" />
+    <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.11.1" />
     <PackageReference Include="NodaTime" Version="2.3.0" />
     <PackageReference Include="Refit" Version="4.3.0" />
   </ItemGroup>

--- a/src/AzureFunctions/AzureFunctions.csproj
+++ b/src/AzureFunctions/AzureFunctions.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>AzureFunctions</AssemblyTitle>
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.13" />
     <PackageReference Include="Microsoft.Azure.Management.AppService.Fluent" Version="1.9.1" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.9.1" />
-    <PackageReference Include="NodaTime" Version="2.2.5" />
+    <PackageReference Include="NodaTime" Version="2.3.0" />
     <PackageReference Include="Refit" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/AzureFunctions/BindPrivateCertificate.cs
+++ b/src/AzureFunctions/BindPrivateCertificate.cs
@@ -46,7 +46,7 @@ namespace MartinCostello.AzureFunctions
             }
             catch (Exception ex)
             {
-                logger?.LogError(ex, "Failed to bind private certificate from Azure blob.");
+                logger?.LogError(ex, "Failed to bind private certificate {Certificate} from Azure blob.", certificate.Name);
                 throw;
             }
         }

--- a/tests/AzureFunctions.Tests/AppService/CertificateServiceTests.cs
+++ b/tests/AzureFunctions.Tests/AppService/CertificateServiceTests.cs
@@ -200,7 +200,7 @@ namespace MartinCostello.AzureFunctions.AppService
             mock.Setup((p) => p.GetApplicationsAsync())
                 .ReturnsAsync(applications ?? Array.Empty<IWebApp>());
 
-            mock.Setup((p) => p.UpdateBindingAsync(It.IsNotNull<IWebApp>(), It.IsNotNull<string>(), It.IsNotNull<byte[]>(), certificatePassword))
+            mock.Setup((p) => p.UpdateBindingAsync(It.IsNotNull<IWebApp>(), It.IsNotNull<string>(), It.IsNotNull<string>(), It.IsNotNull<byte[]>(), certificatePassword))
                 .ReturnsAsync(Mock.Of<IWebApp>());
 
             IAppServiceClient client = mock.Object;

--- a/tests/AzureFunctions.Tests/AzureFunctions.Tests.csproj
+++ b/tests/AzureFunctions.Tests/AzureFunctions.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Tests for AzureFunctions</Description>
     <RootNamespace>MartinCostello.AzureFunctions</RootNamespace>
@@ -14,9 +14,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="JustEat.HttpClientInterception" Version="1.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="Moq" Version="4.8.2" />
-    <PackageReference Include="NodaTime.Testing" Version="2.2.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="Moq" Version="4.8.3" />
+    <PackageReference Include="NodaTime.Testing" Version="2.3.0" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/tests/AzureFunctions.Tests/BindPrivateCertificateTests.cs
+++ b/tests/AzureFunctions.Tests/BindPrivateCertificateTests.cs
@@ -46,13 +46,32 @@ namespace MartinCostello.AzureFunctions
         }
 
         [Fact(Skip = "For local testing of the function using the Storage Emulator.")]
-        public async Task BindPrivateCertificate_Can_Bind_Certificate()
+        public async Task BindPrivateCertificate_Can_Bind_Certificate_Local()
         {
             // Arrange
             string blobName = "CHANGE_ME";
+            var storageAccount = CloudStorageAccount.DevelopmentStorageAccount;
 
+            await BindPrivateCertificateAsync(blobName, storageAccount);
+        }
+
+        [Fact(Skip = "For local testing of the function using the real certificate store.")]
+        public async Task BindPrivateCertificate_Can_Bind_Certificate_Production()
+        {
+            // Arrange
+            string blobName = "CHANGE_ME";
+            string connectionString = "CHANGE_ME";
+
+            var storageAccount = CloudStorageAccount.Parse(connectionString);
+
+            await BindPrivateCertificateAsync(blobName, storageAccount);
+        }
+
+        private async Task BindPrivateCertificateAsync(string blobName, CloudStorageAccount storageAccount)
+        {
+            // Arrange
             var logger = new XunitLogger(_outputHelper);
-            var certificate = CloudStorageAccount.DevelopmentStorageAccount
+            var certificate = storageAccount
                 .CreateCloudBlobClient()
                 .GetContainerReference("certificates")
                 .GetBlockBlobReference(blobName);
@@ -67,6 +86,7 @@ namespace MartinCostello.AzureFunctions
                 Environment.SetEnvironmentVariable(pair.Key, pair.Value.Value<string>());
             }
 
+            // Act and Assert
             await BindPrivateCertificate.Run(certificate, logger);
         }
     }


### PR DESCRIPTION
Fix `Microsoft.Rest.Azure.CloudException` being thrown with the message `No certificate thumbprint provided.`.

Appears that something has changed server-side in Azure that means that the original code no longer works.

Also update _some_ dependencies and log the certificate name if binding fails.