### PR TITLE
Update .NET Core 3.1 SDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.202
+        dotnet-version: 3.1.300
 
     - name: Build, Test and Package
       shell: pwsh

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.202",
+    "version": "3.1.300",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
Update the .NET Core 3.1 SDK to the version for Visual Studio 2019 16.6.
