### PR TITLE
Enable central package versions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "editorconfig.editorconfig",
+    "ms-dotnettools.csharp"
+  ]
+}

--- a/AzureFunctions.ruleset
+++ b/AzureFunctions.ruleset
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="AzureFunctions Rules" Description="This rule set contains rules for the AzureFunctions solution." ToolsVersion="15.0">
   <IncludeAll Action="Warning" />
+  <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+    <Rule Id="CA1031" Action="None" />
+    <Rule Id="CA1054" Action="None" />
+    <Rule Id="CA1056" Action="None" />
+    <Rule Id="CA1303" Action="None" />
+    <Rule Id="CA1308" Action="None" />
+    <Rule Id="CA2007" Action="None" />
+    <Rule Id="CA2227" Action="None" />
+  </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="AD0001" Action="None" />
     <Rule Id="SA1100" Action="None" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,14 +1,7 @@
 <Project>
-  <PropertyGroup>
-    <MicrosoftAzureManagementFluentVersion>1.34.0</MicrosoftAzureManagementFluentVersion>
-  </PropertyGroup>
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
     <Compile Include="$(MSBuildThisFileDirectory)CommonAssemblyInfo.cs" />
-    <PackageReference Include="coverlet.msbuild" Version="2.9.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="ReportGenerator" Version="4.6.2" PrivateAssets="All" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
   </ItemGroup>
   <PropertyGroup>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
@@ -23,6 +16,7 @@
     <GenerateGitMetadata Condition=" '$(CI)' != '' and '$(GenerateGitMetadata)' == '' ">true</GenerateGitMetadata>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <LangVersion>latest</LangVersion>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <NeutralLanguage>en-US</NeutralLanguage>
     <NoWarn>$(NoWarn)</NoWarn>
     <NoWarn Condition=" '$(GenerateDocumentationFile)' != 'true' ">$(NoWarn);SA0001</NoWarn>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,33 @@
+<Project>
+  <PropertyGroup>
+    <MicrosoftAzureManagementFluentVersion>1.34.0</MicrosoftAzureManagementFluentVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="coverlet.msbuild" Version="2.9.0" />
+    <PackageVersion Include="JustEat.HttpClientInterception" Version="3.0.0" />
+    <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.1.0" />
+    <PackageVersion Include="Microsoft.Azure.Management.AppService.Fluent" Version="$(MicrosoftAzureManagementFluentVersion)" />
+    <PackageVersion Include="Microsoft.Azure.Management.Fluent" Version="$(MicrosoftAzureManagementFluentVersion)" />
+    <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
+    <PackageVersion Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageVersion Include="Moq" Version="4.14.5" />
+    <PackageVersion Include="NodaTime" Version="3.0.0" />
+    <PackageVersion Include="NodaTime.Testing" Version="3.0.0" />
+    <PackageVersion Include="Refit" Version="5.1.67" />
+    <PackageVersion Include="ReportGenerator" Version="4.6.1" />
+    <PackageVersion Include="Shouldly" Version="3.0.2" />
+    <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
+    <PackageVersion Include="xunit" Version="2.4.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <PackageReference Include="ReportGenerator" PrivateAssets="All" />
+    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" />
+  </ItemGroup>
+</Project>

--- a/build.ps1
+++ b/build.ps1
@@ -98,8 +98,8 @@ function DotNetTest {
     param([string]$Project)
 
     $nugetPath = Join-Path ($env:USERPROFILE ?? "~") ".nuget\packages"
-    $propsFile = Join-Path $solutionPath "Directory.Build.props"
-    $reportGeneratorVersion = (Select-Xml -Path $propsFile -XPath "//PackageReference[@Include='ReportGenerator']/@Version").Node.'#text'
+    $propsFile = Join-Path $solutionPath "Directory.Packages.props"
+    $reportGeneratorVersion = (Select-Xml -Path $propsFile -XPath "//PackageVersion[@Include='ReportGenerator']/@Version").Node.'#text'
     $reportGeneratorPath = Join-Path $nugetPath "reportgenerator\$reportGeneratorVersion\tools\netcoreapp3.0\ReportGenerator.dll"
 
     $coverageOutput = Join-Path $OutputPath "coverage.cobertura.xml"

--- a/src/AzureFunctions/AppService/CertificateService.cs
+++ b/src/AzureFunctions/AppService/CertificateService.cs
@@ -81,13 +81,13 @@ namespace MartinCostello.AzureFunctions.AppService
             _logger.LogInformation(
                 "Certificate with thumbprint {0} in blob {1} bound to {2:N0} App Service instance host name(s).",
                 data.Thumbprint,
-                certificate.Uri,
+                certificate?.Uri,
                 bindingsUpdated);
 
             return bindingsUpdated;
         }
 
-        private async Task<byte[]> GetCertificateAsync(ICloudBlob blob)
+        private static async Task<byte[]> GetCertificateAsync(ICloudBlob blob)
         {
             byte[] rawData;
 

--- a/src/AzureFunctions/AppService/Client/AppServiceClient.cs
+++ b/src/AzureFunctions/AppService/Client/AppServiceClient.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -56,11 +57,16 @@ namespace MartinCostello.AzureFunctions.AppService.Client
             byte[] certificate,
             string password)
         {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
             using (var certificateFile = new TemporaryCertificateFile(certificate))
             {
                 // See https://github.com/Azure/azure-libraries-for-net/issues/56#issuecomment-335958896
                 await application.Manager.AppServiceCertificates
-                    .Define(string.Format("{0}##{1}#", thumbprint, application.Region.Name))
+                    .Define(string.Format(CultureInfo.InvariantCulture, "{0}##{1}#", thumbprint, application.Region.Name))
                     .WithRegion(application.Region)
                     .WithExistingResourceGroup(application.ResourceGroupName)
                     .WithPfxFile(certificateFile.FileName)

--- a/src/AzureFunctions/AzureFunctions.csproj
+++ b/src/AzureFunctions/AzureFunctions.csproj
@@ -11,12 +11,12 @@
     <UseNETCoreGenerator>true</UseNETCoreGenerator>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
-    <PackageReference Include="Microsoft.Azure.Management.AppService.Fluent" Version="$(MicrosoftAzureManagementFluentVersion)" />
-    <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="$(MicrosoftAzureManagementFluentVersion)" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.2" />
-    <PackageReference Include="NodaTime" Version="3.0.0" />
-    <PackageReference Include="Refit" Version="5.1.67" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" />
+    <PackageReference Include="Microsoft.Azure.Management.AppService.Fluent" />
+    <PackageReference Include="Microsoft.Azure.Management.Fluent" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" />
+    <PackageReference Include="NodaTime" />
+    <PackageReference Include="Refit" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json" CopyToOutputDirectory="PreserveNewest" />

--- a/src/AzureFunctions/BindPrivateCertificate.cs
+++ b/src/AzureFunctions/BindPrivateCertificate.cs
@@ -46,7 +46,7 @@ namespace MartinCostello.AzureFunctions
             }
             catch (Exception ex)
             {
-                logger?.LogError(ex, "Failed to bind private certificate {Certificate} from Azure blob.", certificate.Name);
+                logger?.LogError(ex, "Failed to bind private certificate {Certificate} from Azure blob.", certificate?.Name);
                 throw;
             }
         }

--- a/src/AzureFunctions/DNSimple/DNSimpleService.cs
+++ b/src/AzureFunctions/DNSimple/DNSimpleService.cs
@@ -254,7 +254,7 @@ namespace MartinCostello.AzureFunctions.DNSimple
             IDictionary<string, string> metadata = X509CertificateHelpers.GetMetadata(certificate);
 
             string commonName = certificate.Subject.Substring(3); // Remove "CN=" prefix
-            string safeCommonName = commonName.Replace(".", "-");
+            string safeCommonName = commonName.Replace(".", "-", StringComparison.Ordinal);
 
             string thumbprintLower = certificate.Thumbprint.ToLowerInvariant();
             string timestamp = certificate.NotBefore.ToUniversalTime().ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);

--- a/tests/AzureFunctions.Tests/AzureFunctions.Tests.csproj
+++ b/tests/AzureFunctions.Tests/AzureFunctions.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Tests for AzureFunctions</Description>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CA1707;CS1591</NoWarn>
     <RootNamespace>MartinCostello.AzureFunctions</RootNamespace>
     <Summary>Tests for AzureFunctions</Summary>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
@@ -14,14 +14,14 @@
     <ProjectReference Include="..\..\src\AzureFunctions\AzureFunctions.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JustEat.HttpClientInterception" Version="3.0.0" />
-    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Moq" Version="4.14.5" />
-    <PackageReference Include="NodaTime.Testing" Version="3.0.0" />
-    <PackageReference Include="Shouldly" Version="3.0.2" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
+    <PackageReference Include="JustEat.HttpClientInterception" />
+    <PackageReference Include="MartinCostello.Logging.XUnit" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="NodaTime.Testing" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/tests/AzureFunctions.Tests/DNSimple/DNSimpleServiceTests.cs
+++ b/tests/AzureFunctions.Tests/DNSimple/DNSimpleServiceTests.cs
@@ -69,8 +69,8 @@ namespace MartinCostello.AzureFunctions.DNSimple
 
         private static IDNSimpleApiFactory CreateDNSimpleApiFactory()
         {
-            string publicCertificate = File.ReadAllText("self-signed.cer").Replace("\r\n", "\n");
-            string privateCertificate = File.ReadAllText("self-signed.key").Replace("\r\n", "\n");
+            string publicCertificate = File.ReadAllText("self-signed.cer").Replace("\r\n", "\n", StringComparison.Ordinal);
+            string privateCertificate = File.ReadAllText("self-signed.key").Replace("\r\n", "\n", StringComparison.Ordinal);
 
             var download = new
             {

--- a/tests/AzureFunctions.Tests/MockHttpRequest.cs
+++ b/tests/AzureFunctions.Tests/MockHttpRequest.cs
@@ -10,7 +10,9 @@ using Newtonsoft.Json;
 
 namespace MartinCostello.AzureFunctions
 {
+#pragma warning disable CA1001
     internal sealed class MockHttpRequest : DefaultHttpRequest
+#pragma warning restore CA1001
     {
         private readonly MemoryStream _stream;
 


### PR DESCRIPTION
  * Enable central management of NuGet package versions.
  * Configure missing Roslyn analyzers and fix warnings.
  * Add Visual Studio Code extensions configuration file.
