### PR TITLE
Parameterise NodaTime version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <MicrosoftAzureManagementFluentVersion>1.38.0</MicrosoftAzureManagementFluentVersion>
+    <NodaTimeVersion>3.0.6</NodaTimeVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.msbuild" Version="3.1.0" />
@@ -13,8 +14,8 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
     <PackageVersion Include="Moq" Version="4.16.1" />
-    <PackageVersion Include="NodaTime" Version="3.0.6" />
-    <PackageVersion Include="NodaTime.Testing" Version="3.0.6" />
+    <PackageVersion Include="NodaTime" Version="$(NodaTimeVersion)" />
+    <PackageVersion Include="NodaTime.Testing" Version="$(NodaTimeVersion)" />
     <PackageVersion Include="Refit" Version="5.2.4" />
     <PackageVersion Include="ReportGenerator" Version="4.8.12" />
     <PackageVersion Include="Shouldly" Version="4.0.3" />


### PR DESCRIPTION
Use an MSBuild property to sync the NodaTime packages' version.
